### PR TITLE
Use Zulu time for event times

### DIFF
--- a/src/awscli/plugins/s3touch/__init__.py
+++ b/src/awscli/plugins/s3touch/__init__.py
@@ -148,7 +148,7 @@ class S3Touch(BasicCommand):
                     print('{} is currently not supported'.format(key))
 
     def build_event(self, bucket, file, config):
-        date = datetime.now(timezone.utc).isoformat()
+        date = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         return json.dumps({
             'Records':[{
                 'eventVersion': '2.0', 'eventSource': 'aws:s3', 'awsRegion': self._region,


### PR DESCRIPTION
We need to change the event time format to Zulu in order to use this plugin. 
Amazon seems to be using this format by default. ie https://docs.aws.amazon.com/quicksight/latest/user/formatDate-function.html